### PR TITLE
feat: CRUD 타입별 필터링 및 테이블 중심 분석 구현

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,10 @@ java -jar code-flow-tracer.jar -p /path/to/project -s detailed
 | **세션 복원** | 앱 재시작 시 마지막 분석 결과 자동 복원 |
 | **최근 경로 기억** | 최근 사용한 프로젝트 경로 10개 저장 |
 | **URL 필터** | 특정 URL 패턴만 분석 (예: `/api/user/*`) |
+| **CRUD 실시간 필터** | SELECT/INSERT/UPDATE/DELETE 체크박스로 즉시 필터링 |
 | **출력 스타일** | Compact, Normal, Detailed 선택 |
 | **결과 보기** | 콘솔 스타일 트리 출력, 텍스트 드래그 선택 가능 |
-| **엑셀 저장** | 분석 결과를 엑셀 파일로 저장 |
+| **엑셀 저장** | 분석 결과를 엑셀 파일로 저장 (테이블 영향도 시트 포함) |
 | **폰트 크기 조절** | Ctrl + 마우스 휠로 9px~24px 조절 |
 | **패널 리사이즈** | 좌측 설정 패널 드래그로 크기 조절 |
 
@@ -86,7 +87,19 @@ java -jar code-flow-tracer.jar -p /path/to/project -s detailed
 ![Excel Output](assets/excel-output.png)
 
 > 분석 결과를 엑셀 파일로 내보내 문서화하거나 인수인계 자료로 활용할 수 있습니다.
-> **호출 흐름** 시트와 **SQL 목록** 시트로 구성됩니다.
+> **호출 흐름**, **SQL 목록**, **테이블 영향도** 시트로 구성됩니다.
+
+<details>
+<summary>엑셀 시트 구성 보기</summary>
+
+| 시트 | 내용 |
+|------|------|
+| **요약** | 분석 일시, 프로젝트 경로, 클래스/URL 수 통계 |
+| **호출 흐름** | URL별 Controller → Service → DAO → SQL 흐름, CRUD 타입 |
+| **SQL 목록** | SQL ID, 테이블, 파라미터, 쿼리 원문 |
+| **테이블 영향도** | 테이블별 접근 횟수, CRUD 통계, 접근 URL 목록 |
+
+</details>
 
 ---
 
@@ -97,9 +110,11 @@ java -jar code-flow-tracer.jar -p /path/to/project -s detailed
 | **호출 흐름 추적** | Controller → Service → DAO → SQL | ✅ 완료 |
 | **iBatis/MyBatis 파싱** | XML SQL 매퍼에서 쿼리 추출 | ✅ 완료 |
 | **콘솔 출력** | 트리 형태 + ANSI 색상 지원 | ✅ 완료 |
-| **엑셀 출력** | 호출 흐름 + SQL 목록 시트 | ✅ 완료 |
+| **엑셀 출력** | 호출 흐름 + SQL 목록 + 테이블 영향도 시트 | ✅ 완료 |
 | **Desktop GUI** | Swing 기반, FlatLaf 다크 테마 | ✅ 완료 |
 | **세션 영속성** | 앱 재시작 시 마지막 분석 결과 복원 | ✅ 완료 |
+| **CRUD 타입 필터링** | SELECT/INSERT/UPDATE/DELETE 실시간 필터 | ✅ 완료 |
+| **테이블 중심 분석** | 테이블별 접근 URL/CRUD 역추적 | ✅ 완료 |
 | **Windows 설치 파일** | JRE 번들 포함, Java 설치 불필요 | ✅ 완료 |
 | **전자정부프레임워크** | 레거시 SI 환경 특화 지원 | ✅ 지원 |
 
@@ -140,6 +155,15 @@ java -jar build/libs/code-flow-tracer.jar -p /path/to/project -s detailed
 
 # 엑셀로 출력
 java -jar build/libs/code-flow-tracer.jar -p /path/to/project --excel -o result.xlsx
+
+# SELECT 쿼리만 필터링
+java -jar build/libs/code-flow-tracer.jar -p /path/to/project --sql-type SELECT
+
+# 테이블 목록 및 영향도 분석
+java -jar build/libs/code-flow-tracer.jar -p /path/to/project --list-tables
+
+# 특정 테이블 접근 흐름만 분석
+java -jar build/libs/code-flow-tracer.jar -p /path/to/project --table TB_USER
 ```
 
 <details>
@@ -154,6 +178,9 @@ java -jar build/libs/code-flow-tracer.jar -p /path/to/project --excel -o result.
 | `-d, --output-dir` | 엑셀 저장 디렉토리 (기본: output) |
 | `--excel` | 엑셀 파일로 출력 |
 | `--no-color` | 색상 출력 비활성화 |
+| `--sql-type` | SQL 타입 필터 (예: `SELECT,INSERT`) |
+| `--table` | 특정 테이블 접근 흐름만 표시 |
+| `--list-tables` | 테이블 목록 및 영향도 분석 출력 |
 
 </details>
 

--- a/docs/DEV_LOG.md
+++ b/docs/DEV_LOG.md
@@ -13,7 +13,7 @@
 | [Week 2](./dev-log/WEEK2.md) | 12/18~12/22 | iBatis/MyBatis 파싱, Excel 출력 | Session 5-8 |
 | [Week 3](./dev-log/WEEK3.md) | 12/22~12/26 | GUI 구현 및 배포 | Session 9-17 |
 | [Week 4](./dev-log/WEEK4.md) | 12/30~12/31 | 세션 영속성, 기술 부채 청산 | Session 18-21 |
-| Week 5 (현재) | 01/03~ | CRUD 분석 기능, 블로그 | Session 22-25 |
+| Week 5 (현재) | 01/03~ | CRUD 분석 기능, 블로그 | Session 22-27 |
 
 ---
 
@@ -24,7 +24,7 @@ Week 1: 설계 + 기본 파서 ████████████████�
 Week 2: iBatis + 출력   ████████████████████ 100%
 Week 3: GUI + 테스트    ████████████████████ 100%
 Week 4: 세션 영속성     ████████████████████ 100%
-Week 5: CRUD 분석       ████░░░░░░░░░░░░░░░░ 20%
+Week 5: CRUD 분석       ████████████████░░░░ 80%
 ```
 
 ---
@@ -59,8 +59,8 @@ Week 5: CRUD 분석       ████░░░░░░░░░░░░░░
 - ✅ GitHub Release v1.0.0
 
 ### 예정된 기능
-- [ ] CRUD 타입별 필터링 (#22)
-- [ ] 테이블 중심 분석 (#23)
+- [x] CRUD 타입별 필터링 (#22) - 완료
+- [x] 테이블 중심 분석 (#23) - 완료 (GUI 탭 제외)
 - [ ] CRUD 통계 대시보드 (#24)
 
 ---
@@ -274,7 +274,125 @@ Week 5: CRUD 분석       ████░░░░░░░░░░░░░░
 - GitHub 이슈 #23에 실무 피드백 코멘트 추가 완료
 
 **다음 할 일**
-- [ ] CRUD 필터링 기능 구현 (#22)
-- [ ] 테이블 중심 분석 기능 구현 (#23) ← 실무 피드백 반영
+- [x] CRUD 필터링 기능 구현 (#22)
+- [x] 테이블 중심 분석 기능 구현 (#23) ← 실무 피드백 반영
 - [ ] 러너스하이 마무리 회고 글 작성
 - [ ] (선택) 기술7 Swing GUI 블로그
+
+---
+
+### 2026-01-12 (일) - Session 26
+
+#### Session 26: CRUD 필터링 (#22) 및 테이블 중심 분석 (#23) 구현
+
+**문제**: 실무에서 CRUD 타입별 필터링 및 테이블 역추적 기능 필요
+**해결**: #22, #23 이슈 기능 구현 완료
+
+**오늘 한 일**
+1. **#22 CRUD 타입별 필터링 구현**
+   - CLI: `--sql-type SELECT,INSERT,UPDATE,DELETE` 옵션 추가
+   - FlowAnalyzer: `filterBySqlType()` 메서드 추가
+   - GUI: SQL 타입 체크박스 (SELECT/INSERT/UPDATE/DELETE) 추가
+   - 엑셀: 호출 흐름 시트에 CRUD 타입 컬럼 추가
+   - 세션: CRUD 필터 상태 저장/복원
+
+2. **#23 테이블 중심 분석 구현**
+   - FlowAnalyzer: 테이블 역방향 인덱싱 (`buildTableIndex()`, `TableImpact`, `TableAccess`)
+   - CLI: `--table TB_USER` (특정 테이블 접근 흐름만 표시)
+   - CLI: `--list-tables` (테이블 목록 + CRUD 통계 출력)
+   - 엑셀: "테이블 영향도" 시트 추가 (테이블별 접근 횟수, CRUD 통계, URL/SQL ID)
+
+3. **FlowNode에 유틸리티 메서드 추가**
+   - `copy()`: 노드 복사 (자식 제외)
+   - `clearChildren()`: 자식 노드 초기화
+
+**구현 상세**
+
+| 기능 | 구현 위치 | 내용 |
+|------|----------|------|
+| `--sql-type` | Main.java:77-78 | Picocli 옵션 (콤마 split) |
+| `filterBySqlType()` | FlowAnalyzer.java:122-212 | SQL 타입 필터링 로직 |
+| CRUD 체크박스 | MainFrame.java:79-83, 181-189 | SELECT/INSERT/UPDATE/DELETE |
+| CRUD 컬럼 | ExcelOutput.java:239, 275, 362-364 | 호출 흐름 시트 |
+| `buildTableIndex()` | FlowAnalyzer.java:628-644 | 테이블 역방향 인덱싱 |
+| `--table` | Main.java:80-81 | 테이블 필터링 옵션 |
+| `--list-tables` | Main.java:83-84, 328-384 | 테이블 목록 출력 |
+| 테이블 영향도 시트 | ExcelOutput.java:489-580 | 테이블별 접근 정보 |
+
+**배운 점**
+1. **기존 데이터 활용**: SqlInfo.SqlType, SqlInfo.tables가 이미 존재하여 새로운 파싱 없이 구현 가능
+2. **역방향 인덱싱**: `Map<테이블명, List<접근정보>>` 구조로 빠른 조회 가능
+3. **FlowNode 복사**: 필터링 시 원본 수정 방지를 위해 copy() 메서드 필요
+
+**다음 할 일**
+- [ ] CRUD 필터 실시간 적용 (#025)
+- [ ] GUI 테이블 영향도 탭 추가 (복잡한 UI 변경으로 추후 진행)
+- [ ] CRUD 통계 대시보드 (#24)
+- [ ] 러너스하이 마무리 회고 글 작성
+
+---
+
+### 2026-01-12 (일) - Session 27
+
+#### Session 27: CRUD 필터 실시간 적용 구현
+
+**문제**: GUI에서 CRUD 체크박스 변경 시 재분석 필요 (Issue #025)
+**해결**: 원본 데이터 저장 + UI 레이어 필터링으로 실시간 반영
+
+**문제 분석**
+
+현재 구현의 문제점:
+```java
+// startAnalysis() 내부 - 분석 시점에 필터 적용
+if (sqlTypeFilter != null && !sqlTypeFilter.isEmpty()) {
+    result = analyzer.filterBySqlType(result, sqlTypeFilter);
+}
+currentResult = result;  // ← 필터링된 결과만 저장
+```
+- 원본 데이터가 없어서 필터 변경 시 재분석 필요
+- 엔드포인트 검색은 실시간인데 CRUD는 아님 → UX 불일치
+
+**대안 비교**
+
+| 방식 | 장점 | 단점 | 선택 |
+|------|------|------|------|
+| 원본+필터 이중 저장 | 빠름 | 메모리 2배, 동기화 복잡 | ❌ |
+| 재분석 (현재) | 간단 | 느림, UX 불편 | ❌ |
+| **원본 저장 + UI 필터링** | 빠름, 확장 가능 | 필터 로직 UI 위치 | ✅ |
+
+**기술적 결정 이유**
+1. 엔드포인트 검색과 동일 패턴 → 일관성
+2. 분석 1회 + 필터 즉시 적용 → 반응성
+3. 테이블 필터 추가 시에도 재사용 가능 → 확장성
+
+**구현 완료**
+
+1. `originalResult` 필드 추가 (필터 없는 원본)
+2. CRUD 체크박스에 ActionListener 추가
+3. `applyFiltersAndRefresh()` 메서드 추가
+4. 세션 저장/복원 시 원본 데이터 사용
+
+**변경 파일**
+
+1. `MainFrame.java` - 실시간 필터링 UI
+   - Line 98: `originalResult` 필드 추가
+   - Line 632-636: CRUD 체크박스 ActionListener
+   - Line 1157-1192: `applyFiltersAndRefresh()` 메서드
+   - Line 1055-1074: `saveSession()` - 원본 저장
+   - Line 1076-1139: `restoreSession()` - 원본 복원 + 필터 적용
+
+2. `FlowAnalyzer.java` - 필터링 버그 수정
+   - Line 197-198: Controller 예외 처리 제거
+   - 버그: Controller 노드가 자식 없어도 항상 포함됨
+   - 수정: 모든 노드는 필터에 맞는 자식이 있어야만 포함
+
+**배운 점**
+1. **데이터와 뷰 분리**: 원본 데이터 보존으로 필터 전환 가능
+2. **일관된 패턴**: 엔드포인트 검색과 동일한 실시간 필터링 패턴
+3. **UX 개선**: 재분석 없이 즉시 필터링 → 반응성 향상
+4. **재귀 필터링 주의**: 트리 구조 필터링 시 루트 노드 예외 처리 버그 주의
+
+**다음 할 일**
+- [ ] GUI 테이블 영향도 탭 추가
+- [ ] CRUD 통계 대시보드 (#24)
+- [ ] 러너스하이 마무리 회고 글 작성

--- a/docs/ISSUES.md
+++ b/docs/ISSUES.md
@@ -1083,7 +1083,152 @@ WiX Directory 구조 문제를 우회하여 `cmd.exe /c rmdir`로 직접 삭제:
 
 ## 미해결/진행중 문제
 
-(현재 없음)
+### Issue #025: GUI CRUD 필터 실시간 적용 불가
+
+**발생일**: 2026-01-12
+**상태**: 🟢 해결됨
+
+#### 문제 상황
+- GUI에서 CRUD 타입 체크박스(SELECT, INSERT, UPDATE, DELETE) 선택 후 실시간 필터링이 안 됨
+- 현재는 체크박스 변경 → "분석 시작" 버튼 클릭 → 전체 재분석 필요
+- 반면, 좌측 엔드포인트 검색창은 입력 즉시 실시간 필터링 됨
+
+```
+현재 동작:
+1. 분석 실행 → 결과 표시
+2. CRUD 체크박스 변경
+3. 다시 "분석 시작" 클릭 필요 ← 문제!
+4. 전체 재분석 (느림)
+
+원하는 동작:
+1. 분석 실행 → 결과 표시
+2. CRUD 체크박스 변경 → 즉시 필터링 ← 목표
+```
+
+#### 원인 분석
+
+**현재 구현 방식 (`MainFrame.java`)**:
+```java
+// startAnalysis() 내부 - 분석 시점에 필터 적용
+if (sqlTypeFilter != null && !sqlTypeFilter.isEmpty()) {
+    result = analyzer.filterBySqlType(result, sqlTypeFilter);  // 분석 단계에서 필터링
+}
+currentResult = result;  // 필터링된 결과만 저장
+```
+
+**문제점**:
+- `currentResult`에 **필터링된** 결과만 저장됨
+- 원본 데이터가 없어서 필터 변경 시 재계산 불가능
+- 체크박스 변경 시 전체 재분석 필요 (비효율적)
+
+#### 대안 비교
+
+| 방식 | 장점 | 단점 | 선택 |
+|------|------|------|------|
+| **A. 원본+필터링 이중 저장** | 빠른 필터 전환 | 메모리 2배, 동기화 복잡 | ❌ |
+| **B. 재분석 (현재 방식)** | 구현 간단 | 느림, UX 불편 | ❌ |
+| **C. 원본 저장 + UI 레이어 필터링** | 빠름, 메모리 효율적, 확장 가능 | 필터 로직 UI에 위치 | ✅ |
+
+**선택: C. 원본 저장 + UI 레이어 필터링**
+
+이유:
+1. 엔드포인트 검색창과 동일한 패턴 (일관성)
+2. 분석은 1회만, 필터는 즉시 적용
+3. 향후 테이블 필터 추가 시에도 동일 패턴 재사용 가능
+
+#### 구현 계획
+
+1. **원본 결과 별도 저장**
+   ```java
+   private FlowResult originalResult;  // 필터 없는 원본
+   private FlowResult currentResult;   // 필터 적용된 현재 표시용
+   ```
+
+2. **체크박스에 실시간 리스너 추가**
+   ```java
+   cbSelect.addActionListener(e -> applyFiltersAndRefresh());
+   cbInsert.addActionListener(e -> applyFiltersAndRefresh());
+   // ...
+   ```
+
+3. **필터 적용 메서드 추가**
+   ```java
+   private void applyFiltersAndRefresh() {
+       if (originalResult == null) return;
+
+       FlowResult filtered = originalResult;
+       if (!isAllSqlTypesSelected()) {
+           FlowAnalyzer analyzer = new FlowAnalyzer();
+           filtered = analyzer.filterBySqlType(originalResult, getSelectedSqlTypes());
+       }
+       currentResult = filtered;
+
+       updateSummaryPanel(filtered);
+       updateEndpointList(filtered);
+       resultPanel.displayResult(filtered, getSelectedStyle());
+   }
+   ```
+
+#### 최종 해결
+
+**변경된 파일**: `MainFrame.java`
+
+1. **원본 결과 필드 추가**
+   ```java
+   private FlowResult originalResult;  // 필터 없는 원본 결과
+   private FlowResult currentResult;   // 현재 표시용 (필터 적용된)
+   ```
+
+2. **체크박스에 ActionListener 추가**
+   ```java
+   cbSelect.addActionListener(e -> applyFiltersAndRefresh());
+   cbInsert.addActionListener(e -> applyFiltersAndRefresh());
+   cbUpdate.addActionListener(e -> applyFiltersAndRefresh());
+   cbDelete.addActionListener(e -> applyFiltersAndRefresh());
+   ```
+
+3. **실시간 필터 적용 메서드 추가**
+   ```java
+   private void applyFiltersAndRefresh() {
+       if (originalResult == null) return;
+
+       FlowResult filtered = originalResult;
+       if (!isAllSqlTypesSelected()) {
+           FlowAnalyzer analyzer = new FlowAnalyzer();
+           filtered = analyzer.filterBySqlType(originalResult, getSelectedSqlTypes());
+       }
+       currentResult = filtered;
+
+       updateSummaryPanel(filtered);
+       updateEndpointList(filtered);
+       resultPanel.displayResult(filtered, getSelectedStyle());
+   }
+   ```
+
+4. **세션 저장/복원 시 원본 데이터 사용**
+   - `saveSession()`: `originalResult` 저장
+   - `restoreSession()`: `originalResult`로 복원 후 CRUD 필터 적용
+
+5. **필터링 로직 버그 수정** (`FlowAnalyzer.java`)
+   - 문제: Controller 노드가 자식 없어도 항상 포함됨
+   - 원인: `filterFlowBySqlType()`에서 Controller 예외 처리
+   ```java
+   // 버그 코드
+   if (!filtered.getChildren().isEmpty() || node.getClassType() == ClassType.CONTROLLER) {
+       return filtered;  // Controller는 자식 없어도 반환
+   }
+
+   // 수정 코드
+   if (!filtered.getChildren().isEmpty()) {
+       return filtered;  // 모든 노드는 자식 있어야 반환
+   }
+   ```
+
+#### 배운 점
+- **데이터와 뷰 분리**: 원본 데이터를 보존해야 필터 전환이 가능
+- **일관된 패턴**: 엔드포인트 검색과 동일한 실시간 필터링 패턴 적용
+- **UI 반응성**: 재분석 없이 즉시 필터링 → UX 개선
+- **재귀 필터링 주의**: 트리 구조 필터링 시 루트 노드 예외 처리는 버그 원인이 될 수 있음
 
 ---
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,6 +1,6 @@
 # 할 일 목록 (TODO)
 
-> 최종 수정일: 2026-01-07
+> 최종 수정일: 2026-01-12 (Session 27)
 
 ## 진행 상태 범례
 - ✅ 완료
@@ -213,19 +213,19 @@
 - [x] 기존 사용자 설정 마이그레이션 테스트
 - [x] GUI 삭제 메뉴 통합 ("설정 초기화" + "세션 삭제" → 단일 메뉴)
 
-**CRUD 타입별 필터링 ([#22](https://github.com/KBroJ/Code-Flow-Tracer/issues/22))** ⏳
+**CRUD 타입별 필터링 ([#22](https://github.com/KBroJ/Code-Flow-Tracer/issues/22))** ✅
 > 피드백: 법원도서관 프로젝트 AS-IS 분석 시 CRUD 타입별 필터 필요
-- [ ] CLI `--sql-type` 옵션 추가 (콤마 구분 다중 선택)
-- [ ] GUI 체크박스 다중 선택 UI
-- [ ] 엑셀 CRUD 타입 컬럼 추가
-- [ ] 세션에 필터 상태 저장
+- [x] CLI `--sql-type` 옵션 추가 (콤마 구분 다중 선택)
+- [x] GUI 체크박스 다중 선택 UI
+- [x] 엑셀 CRUD 타입 컬럼 추가
+- [x] 세션에 필터 상태 저장
 
-**테이블 중심 분석 ([#23](https://github.com/KBroJ/Code-Flow-Tracer/issues/23))** ⏳
+**테이블 중심 분석 ([#23](https://github.com/KBroJ/Code-Flow-Tracer/issues/23))** ✅
 > 피드백: 테이블 스키마 변경 시 영향 범위 파악 필요
-- [ ] 테이블 → 접근 코드 역방향 인덱싱
-- [ ] GUI 테이블 영향도 탭 추가
-- [ ] CLI `--table`, `--list-tables` 옵션
-- [ ] 엑셀 테이블 영향도 시트 추가
+- [x] 테이블 → 접근 코드 역방향 인덱싱
+- [ ] GUI 테이블 영향도 탭 추가 (향후 확장)
+- [x] CLI `--table`, `--list-tables` 옵션
+- [x] 엑셀 테이블 영향도 시트 추가
 
 **CRUD 통계 대시보드 ([#24](https://github.com/KBroJ/Code-Flow-Tracer/issues/24))** ⏳
 > 피드백: 프로젝트 전체 CRUD 분포 및 모듈별 역할 파악 필요
@@ -256,7 +256,7 @@
 - [x] 기술3: DAO에서 SQL까지, XML 파싱 ([#57](https://kbroj9210.tistory.com/57))
 - [x] 기술4: 정적 분석의 한계 - 해결할 수 없는 것들 ([#58](https://kbroj9210.tistory.com/58))
 - [x] 기술5: CLI 출력 구현기 ([#59](https://kbroj9210.tistory.com/59)) (선택)
-- [ ] 기술6: Excel 출력 - Apache POI (선택)
+- [x] 기술6: Excel 출력 - Apache POI (선택)
 - [ ] 기술7: Swing으로 모던한 GUI 만들기 (선택)
 - [ ] 기술8: jpackage로 배포하기 (선택)
 - [ ] 기술9: Gson으로 세션 영속성 구현하기 (선택)
@@ -336,6 +336,7 @@
 | #21 | GUI UX 일관성 문제 (커서 표시, 필터 저장, 초기화 불완전) | ✅ 해결 | 2025-12-31 |
 | #23 | URL 필터 적용 시 분석 요약 통계 미반영 (FlowBased 메서드 추가) | ✅ 해결 | 2025-12-31 |
 | #24 | 설치 삭제 시 세션 데이터 유지됨 (WiX RemoveFile 와일드카드) | ✅ 해결 | 2025-12-31 |
+| #25 | GUI CRUD 필터 실시간 적용 불가 + 필터링 버그 | ✅ 해결 | 2026-01-12 |
 
 ---
 

--- a/src/main/java/com/codeflow/analyzer/FlowNode.java
+++ b/src/main/java/com/codeflow/analyzer/FlowNode.java
@@ -225,6 +225,37 @@ public class FlowNode {
     }
 
     /**
+     * 자식 노드 목록 초기화
+     */
+    public void clearChildren() {
+        this.children = new ArrayList<>();
+    }
+
+    /**
+     * 노드 복사 (자식 노드 제외)
+     */
+    public FlowNode copy() {
+        FlowNode copy = new FlowNode();
+        copy.className = this.className;
+        copy.methodName = this.methodName;
+        copy.classType = this.classType;
+        copy.filePath = this.filePath;
+        copy.urlMapping = this.urlMapping;
+        copy.classUrlMapping = this.classUrlMapping;
+        copy.methodUrlMapping = this.methodUrlMapping;
+        copy.httpMethod = this.httpMethod;
+        copy.sqlId = this.sqlId;
+        copy.sqlQuery = this.sqlQuery;
+        copy.sqlInfo = this.sqlInfo;
+        copy.implementedInterfaces = new ArrayList<>(this.implementedInterfaces);
+        copy.parameters = new ArrayList<>(this.parameters);
+        copy.callArguments = new ArrayList<>(this.callArguments);
+        copy.depth = this.depth;
+        copy.children = new ArrayList<>();  // 자식은 복사하지 않음
+        return copy;
+    }
+
+    /**
      * 엔드포인트(Controller 메서드)인지 확인
      */
     public boolean isEndpoint() {

--- a/src/main/java/com/codeflow/session/SessionData.java
+++ b/src/main/java/com/codeflow/session/SessionData.java
@@ -21,6 +21,7 @@ public class SessionData {
     private String outputStyle;           // 출력 스타일 (compact, normal, detailed)
     private List<String> recentPaths;     // 최근 프로젝트 경로 목록
     private String endpointFilter;        // 엔드포인트 검색 필터 (왼쪽 패널)
+    private List<String> sqlTypeFilter;   // SQL 타입 필터 (SELECT, INSERT, UPDATE, DELETE)
 
     public SessionData() {
     }
@@ -86,6 +87,14 @@ public class SessionData {
 
     public void setEndpointFilter(String endpointFilter) {
         this.endpointFilter = endpointFilter;
+    }
+
+    public List<String> getSqlTypeFilter() {
+        return sqlTypeFilter;
+    }
+
+    public void setSqlTypeFilter(List<String> sqlTypeFilter) {
+        this.sqlTypeFilter = sqlTypeFilter;
     }
 
     /**

--- a/src/main/java/com/codeflow/session/SessionManager.java
+++ b/src/main/java/com/codeflow/session/SessionManager.java
@@ -144,7 +144,8 @@ public class SessionManager {
     /**
      * 설정만 저장 (분석 결과는 유지)
      */
-    public boolean saveSettings(java.util.List<String> recentPaths, String urlFilter, String outputStyle, String endpointFilter) {
+    public boolean saveSettings(java.util.List<String> recentPaths, String urlFilter,
+                                String outputStyle, String endpointFilter, java.util.List<String> sqlTypeFilter) {
         // 기존 세션 로드 (분석 결과 유지를 위해)
         SessionData data = loadSettings();
         if (data == null) {
@@ -155,6 +156,7 @@ public class SessionManager {
         data.setUrlFilter(urlFilter);
         data.setOutputStyle(outputStyle);
         data.setEndpointFilter(endpointFilter);
+        data.setSqlTypeFilter(sqlTypeFilter);
 
         return saveSession(data);
     }


### PR DESCRIPTION
## Summary
- GUI에서 CRUD 타입(SELECT/INSERT/UPDATE/DELETE) 실시간 필터링 기능 추가
- CLI에서 `--sql-type`, `--table`, `--list-tables` 옵션 추가
- Excel 출력에 "테이블 영향도" 시트 및 CRUD 컬럼 추가
- 테이블 역방향 인덱싱으로 "이 테이블을 수정하면 어떤 URL이 영향받나?" 분석 가능

Closes #22, Closes #23, Closes #25

## 주요 변경 내용

<details>
<summary>CRUD 타입별 실시간 필터링 (<code>MainFrame.java</code>)</summary>

- CRUD 체크박스 UI 추가 및 ActionListener로 즉시 필터링 ([#L179-L188](https://github.com/KBroJ/Code-Flow-Tracer/blob/ff16d18/src/main/java/com/codeflow/ui/MainFrame.java#L179-L188))
- `originalResult` / `currentResult` 분리로 원본 데이터 보존 ([#L98-L99](https://github.com/KBroJ/Code-Flow-Tracer/blob/ff16d18/src/main/java/com/codeflow/ui/MainFrame.java#L98-L99))
- `applyFiltersAndRefresh()` 메서드로 실시간 UI 갱신 ([#L1187-L1223](https://github.com/KBroJ/Code-Flow-Tracer/blob/ff16d18/src/main/java/com/codeflow/ui/MainFrame.java#L1187-L1223))

</details>

<details>
<summary>CRUD 필터링 핵심 로직 (<code>FlowAnalyzer.java</code>)</summary>

- `filterBySqlType()`: SQL 타입으로 FlowResult 필터링 ([#L121-L160](https://github.com/KBroJ/Code-Flow-Tracer/blob/ff16d18/src/main/java/com/codeflow/analyzer/FlowAnalyzer.java#L121-L160))
- `filterFlowBySqlType()`: 재귀적 트리 필터링 (버그 수정 포함) ([#L178-L211](https://github.com/KBroJ/Code-Flow-Tracer/blob/ff16d18/src/main/java/com/codeflow/analyzer/FlowAnalyzer.java#L178-L211))

</details>

<details>
<summary>테이블 중심 분석 (<code>FlowAnalyzer.java</code>)</summary>

- `TableImpact`, `TableAccess` 내부 클래스 추가 ([#L560-L618](https://github.com/KBroJ/Code-Flow-Tracer/blob/ff16d18/src/main/java/com/codeflow/analyzer/FlowAnalyzer.java#L560-L618))
- `buildTableIndex()`: 테이블 → URL 역방향 인덱싱 ([#L625-L658](https://github.com/KBroJ/Code-Flow-Tracer/blob/ff16d18/src/main/java/com/codeflow/analyzer/FlowAnalyzer.java#L625-L658))
- `filterByTable()`: 특정 테이블 접근 흐름만 필터링 ([#L665-L700](https://github.com/KBroJ/Code-Flow-Tracer/blob/ff16d18/src/main/java/com/codeflow/analyzer/FlowAnalyzer.java#L665-L700))

</details>

<details>
<summary>CLI 옵션 추가 (<code>Main.java</code>)</summary>

- `--sql-type`: CRUD 타입 필터 (예: `--sql-type SELECT,UPDATE`)
- `--table`: 특정 테이블 필터 (예: `--table USER_INFO`)
- `--list-tables`: 테이블 영향도 분석 결과 출력

</details>

<details>
<summary>Excel 출력 개선 (<code>ExcelOutput.java</code>)</summary>

- "호출 흐름" 시트에 CRUD 컬럼 추가 ([#L236](https://github.com/KBroJ/Code-Flow-Tracer/blob/ff16d18/src/main/java/com/codeflow/output/ExcelOutput.java#L236))
- "테이블 영향도" 시트 신규 생성 ([#L489-L580](https://github.com/KBroJ/Code-Flow-Tracer/blob/ff16d18/src/main/java/com/codeflow/output/ExcelOutput.java#L489-L580))

</details>

## Test plan
- [x] GUI에서 CRUD 체크박스 해제 시 해당 SQL 타입 즉시 필터링 확인
- [x] 왼쪽 엔드포인트 목록과 결과 화면 동시 갱신 확인
- [x] 세션 저장/복원 시 원본 데이터 유지 확인
- [x] CLI `--sql-type`, `--table`, `--list-tables` 옵션 동작 확인
- [x] Excel "테이블 영향도" 시트 생성 확인